### PR TITLE
bump evaluate to 0.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sentence-transformers==2.2.2
-evaluate==0.2.2
+evaluate==0.3.0
 #datasets==1.18.4
 #torch==1.10.2
 #transformers==4.17.0


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.